### PR TITLE
[#5] feat: button 컴포넌트 구현

### DIFF
--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { ButtonWrapper, StyledButton, LoadingSpinner } from "./Button.styles";
+
+const Button = ({
+  children,
+  size = "large", // "large" (327×54) 또는 "small" (100×34)
+  variant = "primary", // "primary", "outline", "brown"
+  type = "button",
+  disabled = false,
+  loading = false,
+  onClick,
+  className = "",
+  icon,
+  ...props
+}) => {
+  const handleClick = (e) => {
+    if (disabled || loading) return;
+    onClick?.(e);
+  };
+
+  return (
+    <ButtonWrapper className={className}>
+      <StyledButton
+        type={type}
+        $size={size}
+        $variant={variant}
+        disabled={disabled}
+        $loading={loading}
+        onClick={handleClick}
+        {...props}
+      >
+        {loading && (
+          <LoadingSpinner
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2V6M12 18V22M4.93 4.93L7.76 7.76M16.24 16.24L19.07 19.07M2 12H6M18 12H22M4.93 19.07L7.76 16.24M16.24 7.76L19.07 4.93"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </LoadingSpinner>
+        )}
+        {!loading && icon && icon}
+        {children}
+      </StyledButton>
+    </ButtonWrapper>
+  );
+};
+
+export default Button;

--- a/src/components/common/button/Button.styles.js
+++ b/src/components/common/button/Button.styles.js
@@ -1,0 +1,157 @@
+import styled, { keyframes } from "styled-components";
+
+// 애니메이션
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const StyledButton = styled.button`
+  width: ${(props) => (props.$size === "small" ? "100px" : "327px")};
+  height: ${(props) => (props.$size === "small" ? "34px" : "54px")};
+  border-radius: ${(props) => (props.$size === "small" ? "10px" : "16px")};
+  padding: ${(props) => (props.$size === "small" ? "8px 16px" : "14px 24px")};
+  border: none;
+  font-size: ${(props) => (props.$size === "small" ? "16px" : "18px")};
+  font-weight: ${(props) => (props.$size === "small" ? "400" : "500")};
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${(props) => (props.$size === "small" ? "4px" : "8px")};
+
+  /* 기본 스타일 (큰 버튼) */
+  background-color: var(--color-primary-brown);
+  color: white;
+
+  &:hover {
+    background-color: var(--color-primary-brown-hover);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px var(--color-shadow-brown);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 4px var(--color-shadow-brown);
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--color-shadow-brown);
+  }
+
+  /* 작은 버튼 variant별 스타일 */
+  ${(props) =>
+    props.$size === "small" &&
+    props.$variant === "primary" &&
+    `
+    background-color: var(--color-primary-green);
+    
+    &:hover {
+      background-color: var(--color-primary-green-hover);
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px var(--color-shadow-green);
+    }
+    
+    &:active {
+      transform: translateY(0);
+      box-shadow: 0 2px 4px var(--color-shadow-green);
+    }
+    
+    &:focus {
+      box-shadow: 0 0 0 3px var(--color-shadow-green);
+    }
+  `}
+
+  ${(props) =>
+    props.$size === "small" &&
+    props.$variant === "outline" &&
+    `
+    background-color: transparent;
+    color: var(--color-primary-brown);
+    border: 2px solid var(--color-primary-brown);
+
+    &:hover {
+      background-color: var(--color-primary-brown);
+      color: white;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px var(--color-shadow-brown);
+    }
+  `}
+
+  ${(props) =>
+    props.$size === "small" &&
+    props.$variant === "brown" &&
+    `
+    background-color: var(--color-primary-brown);
+    
+    &:hover {
+      background-color: var(--color-primary-brown-hover);
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px var(--color-shadow-brown);
+    }
+    
+    &:active {
+      transform: translateY(0);
+      box-shadow: 0 2px 4px var(--color-shadow-brown);
+    }
+    
+    &:focus {
+      box-shadow: 0 0 0 3px var(--color-shadow-brown);
+    }
+  `}
+
+  /* 큰 버튼 variant 스타일 */
+  ${(props) =>
+    props.$size !== "small" &&
+    props.$variant === "outline" &&
+    `
+    background-color: transparent;
+    color: var(--color-primary-brown);
+    border: 2px solid var(--color-primary-brown);
+
+    &:hover {
+      background-color: var(--color-primary-brown);
+      color: white;
+      transform: translateY(-1px);
+      box-shadow: 0 4px 8px var(--color-shadow-brown);
+    }
+  `}
+
+  /* 상태별 스타일 */
+  ${(props) =>
+    props.disabled &&
+    `
+    background-color: var(--color-neutral-disabled);
+    color: var(--color-neutral-disabled-text);
+    border: none;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+
+    &:hover {
+      background-color: var(--color-neutral-disabled);
+      transform: none;
+      box-shadow: none;
+    }
+  `}
+
+  /* 로딩 상태 */
+  ${(props) =>
+    props.$loading &&
+    `
+    cursor: wait;
+    opacity: 0.7;
+  `}
+`;
+
+export const LoadingSpinner = styled.svg`
+  animation: ${spin} 1s linear infinite;
+`;

--- a/src/pages/common/TestPage.jsx
+++ b/src/pages/common/TestPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import Input from "../../components/common/input/Input";
+import Button from "../../components/common/button/Button";
 
 const TestContainer = styled.div`
   max-width: 600px;
@@ -17,7 +18,6 @@ const Section = styled.div`
     border-bottom: 2px solid #e5e7eb;
     padding-bottom: 10px;
   }
-  
 `;
 
 const TestPage = () => {
@@ -76,6 +76,65 @@ const TestPage = () => {
           }
           required
         />
+      </Section>
+
+      <Section>
+        <h2>Button 컴포넌트</h2>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+          <div>
+            <h3>크기별 버튼</h3>
+            <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+              <Button size="large">large</Button>
+              <Button size="small">small</Button>
+            </div>
+          </div>
+
+          <div>
+            <h3>작은 버튼 Variant별</h3>
+            <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+              <Button size="small" variant="primary">
+                Primary
+              </Button>
+              <Button size="small" variant="outline">
+                Outline
+              </Button>
+              <Button size="small" variant="brown">
+                Brown
+              </Button>
+            </div>
+          </div>
+
+          <div>
+            <h3>작은 버튼 상태별</h3>
+            <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+              <Button size="small">기본</Button>
+              <Button size="small" disabled>
+                비활성
+              </Button>
+              <Button size="small" loading>
+                로딩중
+              </Button>
+            </div>
+          </div>
+
+          <div>
+            <h3>Variant별 버튼</h3>
+            <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+              <Button variant="primary">Primary</Button>
+              <Button variant="outline">Outline</Button>
+            </div>
+          </div>
+
+          <div>
+            <h3>상태별 버튼</h3>
+            <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+              <Button>기본</Button>
+              <Button disabled>비활성</Button>
+              <Button loading>로딩 중</Button>
+            </div>
+          </div>
+        </div>
       </Section>
     </TestContainer>
   );

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,19 @@
+:root {
+  /* Primary Colors */
+  --color-primary-brown: #775c4a;
+  --color-primary-brown-hover: #5a4537;
+  --color-primary-green: #37ca79;
+  --color-primary-green-hover: #2ba066;
+
+  /* Neutral Colors */
+  --color-neutral-disabled: #e6e6e6;
+  --color-neutral-disabled-text: #999999;
+
+  /* Shadow Colors */
+  --color-shadow-brown: rgba(119, 92, 74, 0.3);
+  --color-shadow-green: rgba(55, 202, 121, 0.3);
+}
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
## ✨ 작업 개요
- button 컴포넌트 구현

## ✅ 주요 작업 내용
- Button 컴포넌트 생성 (327x54, 100x34 크기 지원)
- variant별 스타일링 (primary, outline, brown)
- disabled, loading 상태 지원
- global.css에 색상 변수 추가
- TestPage에 Button 컴포넌트 테스트 추가

## 🔄 관련 이슈
Closes #5 

## 📸 스크린샷 (선택)
<img width="798" height="527" alt="image" src="https://github.com/user-attachments/assets/03488432-4ad8-4cce-b0bf-25d8d8d1335f" />

## 📝 비고
- TestPage 코드 업데이트 해놨습니당
