### PR TITLE
feat: wishlist 페이지 구현 및 영업상태 커스텀훅 분리

### DIFF
--- a/src/components/common/header/BackHeader.styles.js
+++ b/src/components/common/header/BackHeader.styles.js
@@ -5,7 +5,7 @@ const Header = styled.header`
   align-items: center;
   gap: 16px;
   padding: 16px 30px;
-  background-color: #ffffff;
+  background-color: #f5f5f5;
   border-bottom: 1px solid #e5e7eb;
   position: sticky;
   top: 0;

--- a/src/components/common/header/Header.jsx
+++ b/src/components/common/header/Header.jsx
@@ -57,7 +57,7 @@ const Header = ({ userInfo, onLogout, title }) => {
   };
 
   const handleLogoClick = () => {
-    navigate("/mainpage");
+    navigate("/");
   };
 
   const handleInventoryMap = () => {
@@ -76,21 +76,15 @@ const Header = ({ userInfo, onLogout, title }) => {
   };
 
   const handleFavorites = () => {
-    // TODO: 찜 페이지 구현 후 링크 연결
-    console.log("찜 페이지로 이동");
+    navigate("/wishlist");
     setDrawerOpen(false);
   };
 
   return (
     <>
       <HeaderContainer>
-        <Brand>
-          <BrandLogo
-            src={textLogo}
-            alt="심봤다"
-            onClick={handleLogoClick}
-            style={{ cursor: "pointer" }}
-          />
+        <Brand onClick={handleLogoClick}>
+          <BrandLogo src={textLogo} alt="심봤다" />
         </Brand>
         {title && <HeaderTitle>{title}</HeaderTitle>}
         <HamburgerButton

--- a/src/components/common/header/Header.styles.js
+++ b/src/components/common/header/Header.styles.js
@@ -5,7 +5,7 @@ const HeaderContainer = styled.header`
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  background-color: inherit;
+  background-color: #f5f5f5;
   position: fixed;
   top: 0;
   left: 0;
@@ -17,6 +17,7 @@ const Brand = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
+  cursor: pointer;
 `;
 
 const BrandLogo = styled.img`
@@ -24,12 +25,13 @@ const BrandLogo = styled.img`
 `;
 
 const HeaderTitle = styled.h1`
-  font-size: 18px;
-  font-weight: 600;
-  color: #1f2937;
+  font-size: 20px;
+  font-weight: 700;
+  color: #000;
   margin: 0;
   flex: 1;
   text-align: center;
+  font-family: Pretendard;
 `;
 
 const HamburgerButton = styled.button`

--- a/src/components/common/header/WishListHeader.jsx
+++ b/src/components/common/header/WishListHeader.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import menuIcon from "../../../assets/icons/menu.png";
 import starsquirrelIcon from "../../../assets/icons/starsquirrel.png";
 import LocationIcon from "../../../assets/icons/Location.png";
@@ -39,6 +40,7 @@ const PageTitle = styled.h1`
 `;
 
 const WishListHeader = ({ userInfo, onLogout }) => {
+  const navigate = useNavigate();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const drawerRef = useRef(null);
 
@@ -66,7 +68,7 @@ const WishListHeader = ({ userInfo, onLogout }) => {
   return (
     <>
       <HeaderContainer>
-        <Brand>
+        <Brand onClick={() => navigate("/")}>
           <BrandLogo src={textLogo} alt="심봤다" />
         </Brand>
         <PageTitle>찜 목록</PageTitle>
@@ -90,23 +92,23 @@ const WishListHeader = ({ userInfo, onLogout }) => {
           </ProfileInfo>
         </DrawerHeader>
         <DrawerList>
-          <DrawerItem>
+          <DrawerItem onClick={() => navigate("/inventory-map")}>
             <img src={LocationIcon} alt="재고지도" width={20} height={20} />
             재고 지도
           </DrawerItem>
-          <DrawerItem>
+          <DrawerItem onClick={() => navigate("/special-price")}>
             <img src={DiscountIcon} alt="특가상품" width={20} height={20} />
             특가 상품
           </DrawerItem>
-          <DrawerItem>
+          <DrawerItem onClick={() => navigate("/recommended")}>
             <img src={GoodQualityIcon} alt="추천상품" width={20} height={20} />
             추천 상품
           </DrawerItem>
-          <DrawerItem>
+          <DrawerItem onClick={() => navigate("/order-history")}>
             <img src={BillIcon} alt="예약내역" width={20} height={20} />
             예약 내역
           </DrawerItem>
-          <DrawerItem>
+          <DrawerItem onClick={() => navigate("/wishlist")}>
             <img src={FavoriteIcon} alt="찜" width={20} height={20} />찜
           </DrawerItem>
         </DrawerList>

--- a/src/components/common/products/WishListCard.jsx
+++ b/src/components/common/products/WishListCard.jsx
@@ -1,0 +1,83 @@
+import React, { useState, useMemo } from "react";
+import likeIcon from "../../../assets/icons/like/like.svg";
+import unlikeIcon from "../../../assets/icons/like/unlike.svg";
+import defaultImage from "../../../assets/images/defaultImage.svg";
+import {
+  CardContainer,
+  DistanceBadge,
+  LikeButton,
+  LikeIcon,
+  CardContent,
+  StoreName,
+  ProductName,
+  CategoryTag,
+  ProductImage,
+  PriceSection,
+  DiscountRate,
+  Price,
+} from "./WishListCard.styles";
+
+const WishListCard = ({
+  id,
+  distance = "300m",
+  storeName,
+  productName,
+  category,
+  imageUrl,
+  originalPrice,
+  discountPrice,
+  isLiked = true,
+  onLikeToggle,
+  onClick,
+}) => {
+  const [liked, setLiked] = useState(isLiked);
+
+  const discountRate = useMemo(() => {
+    if (originalPrice <= discountPrice) return 0;
+    const rate = Math.round(
+      ((originalPrice - discountPrice) / originalPrice) * 100
+    );
+    return rate > 0 ? rate : 0;
+  }, [originalPrice, discountPrice]);
+
+  const displayImage = imageUrl || defaultImage;
+
+  const handleLikeClick = (e) => {
+    e.stopPropagation();
+    const newLikedState = !liked;
+    setLiked(newLikedState);
+    onLikeToggle?.(id, newLikedState);
+  };
+
+  return (
+    <CardContainer onClick={onClick}>
+      <DistanceBadge>{distance}</DistanceBadge>
+      <LikeButton
+        onClick={handleLikeClick}
+        aria-label={liked ? "찜 취소" : "찜하기"}
+      >
+        <LikeIcon
+          src={liked ? likeIcon : unlikeIcon}
+          alt={liked ? "찜됨" : "찜 안됨"}
+        />
+      </LikeButton>
+
+      <CardContent>
+        <StoreName>{storeName}</StoreName>
+        <ProductName>
+          {productName}
+          {category && <CategoryTag>{category}</CategoryTag>}
+        </ProductName>
+      </CardContent>
+
+      <ProductImage src={displayImage} alt={productName} />
+
+      <PriceSection>
+        {discountRate > 0 && <DiscountRate>{discountRate}%</DiscountRate>}
+        <Price>{discountPrice.toLocaleString()}원</Price>
+      </PriceSection>
+    </CardContainer>
+  );
+};
+
+export default WishListCard;

--- a/src/components/common/products/WishListCard.styles.js
+++ b/src/components/common/products/WishListCard.styles.js
@@ -1,0 +1,127 @@
+import styled from "styled-components";
+
+export const CardContainer = styled.div`
+  position: relative;
+
+  background: rgba(128, 128, 128, 0.1);
+  border-radius: 12px;
+  padding: 16px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+export const DistanceBadge = styled.div`
+  position: absolute;
+  top: 12px;
+  left: 16px;
+
+  color: #8a8a8a;
+  font-family: Pretendard;
+  font-size: 12px;
+  font-weight: 500;
+`;
+
+export const LikeButton = styled.button`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 2;
+  padding: 4px;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+`;
+
+export const LikeIcon = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+
+export const CardContent = styled.div`
+  margin-bottom: 12px;
+`;
+
+export const StoreName = styled.h3`
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 4px 0;
+  line-height: 1.2;
+  margin-top: 13px;
+`;
+
+export const ProductName = styled.h4`
+  font-size: 18px;
+  font-weight: 700;
+  color: #000;
+  margin: 0 0 4px 0;
+  line-height: 1.2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const CategoryTag = styled.span`
+  display: inline-block;
+  background: #ddcfc5;
+  color: #5d5752;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+`;
+
+export const ProductImage = styled.img`
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  background: #e9ecef;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6c757d;
+  font-size: 12px;
+
+  &::before {
+    content: "상품 이미지";
+  }
+`;
+
+export const TimeRemaining = styled.div`
+  font-size: 12px;
+  color: #6c757d;
+  margin-bottom: 12px;
+  text-align: center;
+  font-weight: 500;
+`;
+
+export const PriceSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: right;
+`;
+
+export const DiscountRate = styled.span`
+  color: #37ca79;
+  font-size: 20px;
+  font-weight: 700;
+`;
+
+export const Price = styled.span`
+  color: #000;
+  font-size: 20px;
+  font-weight: 700;
+`;

--- a/src/hooks/useStoreStatus.js
+++ b/src/hooks/useStoreStatus.js
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import { toggleStoreStatus } from "../api/seller";
+
+const STORE_STATUS_KEY = "store_open_status";
+
+export const useStoreStatus = () => {
+  const [isOpen, setIsOpen] = useState(() => {
+    const saved = localStorage.getItem(STORE_STATUS_KEY);
+    return saved !== null ? JSON.parse(saved) : true;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORE_STATUS_KEY, JSON.stringify(isOpen));
+  }, [isOpen]);
+
+  const handleToggleOpenStatus = async () => {
+    try {
+      console.log("현재 영업 상태:", isOpen);
+      console.log("영업 상태 변경 요청 중...");
+
+      const result = await toggleStoreStatus();
+      console.log("API 응답:", result);
+
+      if (result && typeof result.is_open === "boolean") {
+        setIsOpen(result.is_open);
+        alert(
+          `영업 상태가 ${
+            result.is_open ? "영업중" : "마감"
+          }으로 변경되었습니다.`
+        );
+        console.log("영업 상태 업데이트 완료:", result.is_open);
+        return { success: true };
+      } else {
+        const fallbackMsg =
+          "상점 정보가 없습니다. 상점 등록을 먼저 완료하세요.";
+        alert(fallbackMsg);
+        return { success: false, message: fallbackMsg };
+      }
+    } catch (err) {
+      console.error("Failed to toggle store status:", err);
+      const msg = err?.message || "영업 상태 변경에 실패했습니다.";
+      alert(msg);
+      return { success: false, message: msg };
+    }
+  };
+
+  return {
+    isOpen,
+    handleToggleOpenStatus,
+  };
+};

--- a/src/pages/main/MainPageSeller.jsx
+++ b/src/pages/main/MainPageSeller.jsx
@@ -6,7 +6,6 @@ import {
   getSellerOrders,
   acceptOrder,
   rejectOrder,
-  toggleStoreStatus,
 } from "../../api/seller";
 import { logout } from "../../api/auth";
 import Button from "../../components/common/button/Button";
@@ -35,15 +34,16 @@ import {
 } from "./MainPageSeller.styles";
 
 import { Backdrop } from "../../components/common/header/HeaderSeller.styles";
+import { useStoreStatus } from "../../hooks/useStoreStatus";
 
 import ImportantIcon from "../../assets/icons/Important.png";
 import HeaderSeller from "../../components/common/header/HeaderSeller";
 
 function MainPageSeller() {
   const navigate = useNavigate();
+  const { isOpen, handleToggleOpenStatus } = useStoreStatus();
   const [userInfo, setUserInfo] = useState(null);
   const [storeInfo, setStoreInfo] = useState(null);
-  const [isOpen, setIsOpen] = useState(true);
   const [rejectModalOpen, setRejectModalOpen] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
   const [currentRejectOrder, setCurrentRejectOrder] = useState(null);
@@ -82,9 +82,8 @@ function MainPageSeller() {
         ]);
         setUserInfo(userData);
         setStoreInfo(storeData);
-        if (storeData && storeData.length > 0) {
-          setIsOpen(storeData[0].is_open);
-        }
+        // storeData에서 영업 상태를 가져오지만, 커스텀 훅에서 관리
+        // setIsOpen(storeData[0].is_open);
       } catch (err) {
         console.error("Failed to fetch user/store info:", err);
         navigate("/signin-seller");
@@ -186,38 +185,6 @@ function MainPageSeller() {
     } catch (err) {
       console.error("Failed to logout:", err);
       alert("로그아웃 중 오류가 발생했습니다.");
-    }
-  };
-
-  const handleToggleOpenStatus = async () => {
-    try {
-      console.log("현재 영업 상태:", isOpen);
-      console.log("영업 상태 변경 요청 중...");
-
-      const result = await toggleStoreStatus();
-      console.log("API 응답:", result);
-
-      if (result && typeof result.is_open === "boolean") {
-        setIsOpen(result.is_open);
-        alert(
-          `영업 상태가 ${
-            result.is_open ? "영업중" : "마감"
-          }으로 변경되었습니다.`
-        );
-        console.log("영업 상태 업데이트 완료:", result.is_open);
-      } else {
-        const fallbackMsg =
-          "상점 정보가 없습니다. 상점 등록을 먼저 완료하세요.";
-        alert(fallbackMsg);
-        navigate("/store-registration");
-      }
-    } catch (err) {
-      console.error("Failed to toggle store status:", err);
-      const msg = err?.message || "영업 상태 변경에 실패했습니다.";
-      alert(msg);
-      if (typeof msg === "string" && msg.includes("상점")) {
-        navigate("/store-registration");
-      }
     }
   };
 

--- a/src/pages/main/OrderCompleted.jsx
+++ b/src/pages/main/OrderCompleted.jsx
@@ -4,6 +4,7 @@ import { getSellerMe } from "../../api/seller";
 import { logout } from "../../api/auth";
 import CompletedCard from "../../components/order/CompletedCard";
 import Button from "../../components/common/button/Button";
+import { useStoreStatus } from "../../hooks/useStoreStatus";
 import {
   PageContainer,
   Content,
@@ -20,7 +21,7 @@ import HeaderSeller from "../../components/common/header/HeaderSeller";
 
 export default function OrderCompleted() {
   const navigate = useNavigate();
-  const [isOpen, setIsOpen] = useState(true);
+  const { isOpen, handleToggleOpenStatus } = useStoreStatus();
   const [userInfo, setUserInfo] = useState(null);
 
   // 샘플 주문 데이터 (날짜별로 그룹화)
@@ -80,7 +81,7 @@ export default function OrderCompleted() {
         <OpenStatusSection>
           <Button
             variant={isOpen ? "open" : "close"}
-            onClick={() => setIsOpen(!isOpen)}
+            onClick={handleToggleOpenStatus}
           >
             {isOpen ? "open" : "close"}
           </Button>

--- a/src/pages/main/OrderInProgress.jsx
+++ b/src/pages/main/OrderInProgress.jsx
@@ -4,6 +4,7 @@ import { getSellerMe } from "../../api/seller";
 import { logout } from "../../api/auth";
 import OrderProgressCard from "../../components/order/OrderProgressCard";
 import Button from "../../components/common/button/Button";
+import { useStoreStatus } from "../../hooks/useStoreStatus";
 import {
   PageContainer,
   Content,
@@ -18,7 +19,7 @@ import HeaderSeller from "../../components/common/header/HeaderSeller";
 
 export default function OrderInProgress() {
   const navigate = useNavigate();
-  const [isOpen, setIsOpen] = useState(true);
+  const { isOpen, handleToggleOpenStatus } = useStoreStatus();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [userInfo, setUserInfo] = useState(null);
   const drawerRef = useRef(null);
@@ -54,7 +55,7 @@ export default function OrderInProgress() {
         <OpenStatusSection>
           <Button
             variant={isOpen ? "open" : "close"}
-            onClick={() => setIsOpen(!isOpen)}
+            onClick={handleToggleOpenStatus}
           >
             {isOpen ? "open" : "close"}
           </Button>

--- a/src/pages/main/ProductRegister.jsx
+++ b/src/pages/main/ProductRegister.jsx
@@ -5,7 +5,6 @@ import {
   getSellerProducts,
   createProduct,
   deleteProduct,
-  toggleStoreStatus,
 } from "../../api/seller";
 import { logout, getCategories } from "../../api/auth";
 import Button from "../../components/common/button/Button";
@@ -47,14 +46,15 @@ import {
 
 import HeaderSeller from "../../components/common/header/HeaderSeller";
 import { Backdrop } from "../../components/common/header/HeaderSeller.styles";
+import { useStoreStatus } from "../../hooks/useStoreStatus";
 import closeIcon from "../../assets/icons/x.png";
 import ProductCard from "../../components/product/ProductCard";
 
 function ProductRegister() {
   const navigate = useNavigate();
+  const { isOpen, handleToggleOpenStatus } = useStoreStatus();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [userInfo, setUserInfo] = useState(null);
-  const [isOpen, setIsOpen] = useState(true);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [products, setProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -292,38 +292,6 @@ function ProductRegister() {
     setProducts((prev) =>
       prev.map((p) => (p.id === id ? { ...p, onSale: !p.onSale } : p))
     );
-  };
-
-  const handleToggleOpenStatus = async () => {
-    try {
-      console.log("현재 영업 상태:", isOpen);
-      console.log("영업 상태 변경 요청 중...");
-
-      const result = await toggleStoreStatus();
-      console.log("API 응답:", result);
-
-      if (result && typeof result.is_open === "boolean") {
-        setIsOpen(result.is_open);
-        alert(
-          `영업 상태가 ${
-            result.is_open ? "영업중" : "마감"
-          }으로 변경되었습니다.`
-        );
-        console.log("영업 상태 업데이트 완료:", result.is_open);
-      } else {
-        const fallbackMsg =
-          "상점 정보가 없습니다. 상점 등록을 먼저 완료하세요.";
-        alert(fallbackMsg);
-        navigate("/store-registration");
-      }
-    } catch (err) {
-      console.error("Failed to toggle store status:", err);
-      const msg = err?.message || "영업 상태 변경에 실패했습니다.";
-      alert(msg);
-      if (typeof msg === "string" && msg.includes("상점")) {
-        navigate("/store-registration");
-      }
-    }
   };
 
   return (

--- a/src/pages/main/WishList.jsx
+++ b/src/pages/main/WishList.jsx
@@ -1,23 +1,100 @@
-import React from "react";
-import WishListHeader from "../../components/common/header/WishListHeader";
-import { WishListContainer, WishListContent } from "./WishList.styles";
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "../../components/common/header/Header";
+import WishListCard from "../../components/common/products/WishListCard";
+import {
+  Container,
+  CardsGrid,
+  EmptyState,
+  EmptyText,
+  EmptyImage,
+} from "./WishList.styles";
+import cryingCharacter from "../../assets/images/crying-character.svg";
 
 const WishList = () => {
-  const userInfo = {
-    name: "사용자",
+  const navigate = useNavigate();
+  const [wishListItems, setWishListItems] = useState([]);
+  const [userInfo, setUserInfo] = useState({ name: "사용자" });
+
+  useEffect(() => {
+    const mockWishListItems = [
+      {
+        id: 1,
+        distance: "300m",
+        storeName: "김치만 선생",
+        productName: "돼지주물럭",
+        category: "치킨",
+        imageUrl: null,
+        originalPrice: 8000,
+        discountPrice: 5900,
+        isLiked: true,
+      },
+      {
+        id: 2,
+        distance: "300m",
+        storeName: "김치만 선생",
+        productName: "돼지주물럭",
+        category: "패스트푸드",
+        imageUrl: null,
+        originalPrice: 8000,
+        discountPrice: 5900,
+        isLiked: true,
+      },
+      {
+        id: 3,
+        distance: "300m",
+        storeName: "김치만 선생",
+        productName: "돼지주물럭",
+        category: "치킨",
+        imageUrl: null,
+        originalPrice: 8000,
+        discountPrice: 5900,
+        isLiked: true,
+      },
+    ];
+
+    setWishListItems(mockWishListItems);
+  }, []);
+
+  const handleLikeToggle = (productId, isLiked) => {
+    if (!isLiked) {
+      setWishListItems((prev) => prev.filter((item) => item.id !== productId));
+    }
+
+    console.log(`상품 ${productId} 찜 ${isLiked ? "추가" : "제거"}`);
+  };
+
+  const handleProductClick = (productId) => {
+    navigate(`/registeration/${productId}`);
   };
 
   const handleLogout = () => {
     console.log("로그아웃");
+    navigate("/signin");
   };
 
   return (
-    <WishListContainer>
-      <WishListHeader userInfo={userInfo} onLogout={handleLogout} />
-      <WishListContent>
-        <p>찜 컴포넌트 추가하기</p>
-      </WishListContent>
-    </WishListContainer>
+    <Container>
+      <Header userInfo={userInfo} onLogout={handleLogout} title="찜 목록" />
+
+      {wishListItems.length > 0 ? (
+        <CardsGrid>
+          {wishListItems.map((item) => (
+            <WishListCard
+              key={item.id}
+              {...item}
+              onLikeToggle={handleLikeToggle}
+              onClick={() => handleProductClick(item.id)}
+            />
+          ))}
+        </CardsGrid>
+      ) : (
+        <EmptyState>
+          <EmptyImage src={cryingCharacter} alt="cryingCharacter" />
+          <EmptyText>아직 찜 내역이 없습니다</EmptyText>
+        </EmptyState>
+      )}
+    </Container>
   );
 };
 

--- a/src/pages/main/WishList.styles.js
+++ b/src/pages/main/WishList.styles.js
@@ -1,11 +1,61 @@
 import styled from "styled-components";
 
-export const WishListContainer = styled.div`
-  min-height: 100%;
-  background-color: #fff;
+export const Container = styled.div`
+  min-height: 100vh;
+  background: #f5f5f5;
+  padding-bottom: 20px;
+  margin-top: 100px;
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 `;
 
-export const WishListContent = styled.div`
-  padding: 20px;
-  margin-top: 82px;
+export const CardsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  padding: 0 16px;
+  max-width: 1400px;
+  margin: 0 auto;
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+    padding: 0 24px;
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 32px;
+    padding: 0 32px;
+  }
+
+  @media (min-width: 1400px) {
+    grid-template-columns: repeat(5, 1fr);
+    gap: 40px;
+    padding: 0 40px;
+  }
+`;
+
+export const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 150px 20px;
+  text-align: center;
+`;
+
+export const EmptyText = styled.p`
+  font-size: 16px;
+  color: #6c757d;
+  margin: 0;
+  font-weight: 500;
+`;
+
+export const EmptyImage = styled.img`
+  width: 120px;
+  height: 120px;
+  margin-bottom: 16px;
+  opacity: 0.7;
 `;


### PR DESCRIPTION
## ✅ 주요 작업 내용
- header,backheader 색 수정
- header에 찜 경로 추가 
- wishlist 페이지 구현
- wishlist 카드 구현  (유통기한 d-day는 뻈음 ->자리배치 이상함 + 상세페이지에 있으므로 불필요하다 생각)
- OrderInProgress.jsx, OrderCompleted.jsx 가게 open,close 상태 추가 (api연결할 때 까먹음)
- 영업상태 (handletoggleopenstatus 코드) 커스텀훅으로 분리 

